### PR TITLE
Fix GRUB issue in Tiger Lake controller

### DIFF
--- a/grub-core/loader/i386/linux.c
+++ b/grub-core/loader/i386/linux.c
@@ -306,6 +306,12 @@ grub_linux_setup_video (struct linux_kernel_params *params)
   params->lfb_line_len = mode_info.pitch;
 
   params->lfb_base = (grub_size_t) framebuffer;
+  
+#if defined (GRUB_MACHINE_EFI) && defined (__x86_64__)
+  params->ext_lfb_base = (grub_size_t) (((grub_uint64_t)(grub_size_t) framebuffer) >> 32);
+  params->capabilities |= VIDEO_CAPABILITY_64BIT_BASE;
+#endif
+
   params->lfb_size = ALIGN_UP (params->lfb_line_len * params->lfb_height, 65536);
 
   params->red_mask_size = mode_info.red_mask_size;

--- a/include/grub/i386/linux.h
+++ b/include/grub/i386/linux.h
@@ -43,6 +43,9 @@
 
 #define GRUB_LINUX_CL_MAGIC		0xA33F
 
+#define VIDEO_CAPABILITY_SKIP_QUIRKS	(1 << 0)
+#define VIDEO_CAPABILITY_64BIT_BASE	(1 << 1)	/* Frame buffer base is 64-bit. */
+
 #ifdef __x86_64__
 
 #define GRUB_LINUX_EFI_SIGNATURE	\
@@ -188,8 +191,9 @@ struct linux_kernel_params
   grub_uint16_t lfb_pages;		/* 32 */
   grub_uint16_t vesa_attrib;		/* 34 */
   grub_uint32_t capabilities;		/* 36 */
+  grub_uint32_t ext_lfb_base;		/* 3a */
 
-  grub_uint8_t padding3[0x40 - 0x3a];
+  grub_uint8_t padding3[0x40 - 0x3e];
 
   grub_uint16_t apm_version;		/* 40 */
   grub_uint16_t apm_code_segment;	/* 42 */


### PR DESCRIPTION
Adds the support for 64-bit linear frame buffer address in GRUB to fix the issue where GRUB is not loaded into display in Tiger Lake controller. 